### PR TITLE
typeof check for string, if string cast data as array for map function

### DIFF
--- a/src/ApiClient.js
+++ b/src/ApiClient.js
@@ -688,6 +688,11 @@
         } else if (Array.isArray(type)) {
           // for array type like: ['String']
           var itemType = type[0];
+          if (typeof(data) === 'string') {
+            return [data].map(function(item) {
+              return exports.convertToType(item, itemType);
+            });
+          }
           return data.map(function(item) {
             return exports.convertToType(item, itemType);
           });


### PR DESCRIPTION
**Reference Issue:**
#69 

**What does this fix?**
When querying the ValidateExportCompliance endpoint using the node client the function `convertToType()` in [ApiClient.js](src/ApiClient.js) will attempt to run the `.map()` function on a String.

This adds a check for data of type String, and if data is of type String it will cast it as an array so that the `.map()` function can successfully run on the data variable.