### PR TITLE
fix: Axios dependency without CVE-2026-25639

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "fs": false
   },
   "dependencies": {
-    "axios": "1.12.0",
+    "axios": "1.13.5",
     "axios-cookiejar-support": "4.0.7",
     "tough-cookie": "4.1.3",
     "https-proxy-agent": "^7.0.0",


### PR DESCRIPTION
Our builds fails because we require all dependencies to be free of vulnerabilities classified as greater than or equal to 'high'.